### PR TITLE
Expand drop area

### DIFF
--- a/frontend/src/router/views/AlbumEdit.vue
+++ b/frontend/src/router/views/AlbumEdit.vue
@@ -293,18 +293,19 @@ onClickOutside(deletewrap, () => {
 </script>
 
 <template>
-  <div class="hi-album-upload album-edit">
+  <div
+    id="drop-area" class="hi-album-upload album-edit"
+    @dragenter="draggingOver = true"
+    @mouseleave="draggingOver = false"
+  >
     <LoadingSpin v-if="getLoading('edit')" class="center-page dark" />
 
     <!-- <template v-else-if="false"> no data </template> -->
     <div class="album-upload-layout">
       <div class="album-upload-items">
         <div
-          id="drop-area"
           class="album-drag-input"
           :class="{ hovering: draggingOver, empty: files.values.length === 0 }"
-          @dragenter="draggingOver = true"
-          @mouseleave="draggingOver = false"
         >
           <input id="draginput" name="draginput" type="file" multiple accept="image/*">
           <label for="draginput">

--- a/frontend/src/router/views/AlbumUpload.vue
+++ b/frontend/src/router/views/AlbumUpload.vue
@@ -273,7 +273,11 @@ function dragCompare() {
 </script>
 
 <template>
-  <div class="hi-album-upload" :class="{ 'has-drafts': drafts && !isEmpty(drafts) }">
+  <div
+    id="drop-area" class="hi-album-upload" :class="{ 'has-drafts': drafts && !isEmpty(drafts) }"
+    @dragenter="draggingOver = true"
+    @mouseleave="draggingOver = false"
+  >
     <LoadingSpin v-if="getLoading('album-upload')" class="dark center-page" />
 
     <div v-if="drafts && !isEmpty(drafts)" class="album-drafts">
@@ -292,11 +296,9 @@ function dragCompare() {
         </div>
 
         <div
-          id="drop-area"
+
           class="album-drag-input"
           :class="{ hovering: draggingOver, empty: files.values.length === 0 }"
-          @dragenter="draggingOver = true"
-          @mouseleave="draggingOver = false"
         >
           <input id="draginput" name="draginput" type="file" multiple accept="image/*">
           <label for="draginput">


### PR DESCRIPTION
It is now possible to drag & drop images everywhere within the red area 
<img width="1802" height="1202" alt="image" src="https://github.com/user-attachments/assets/93d47aec-a655-44b1-ba0b-36becde759bb" />

Close #190 